### PR TITLE
all: use New() constructor function for simplicity

### DIFF
--- a/mag3110/mag3110.go
+++ b/mag3110/mag3110.go
@@ -13,11 +13,11 @@ type Device struct {
 	bus machine.I2C
 }
 
-// NewI2C creates a new MAG3110 connection. The I2C bus must already be
+// New creates a new MAG3110 connection. The I2C bus must already be
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func NewI2C(bus machine.I2C) Device {
+func New(bus machine.I2C) Device {
 	return Device{bus}
 }
 

--- a/mma8653/mma8653.go
+++ b/mma8653/mma8653.go
@@ -14,11 +14,11 @@ type Device struct {
 	bus machine.I2C
 }
 
-// NewI2C creates a new MMA8653 connection. The I2C bus must already be
+// New creates a new MMA8653 connection. The I2C bus must already be
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func NewI2C(bus machine.I2C) Device {
+func New(bus machine.I2C) Device {
 	return Device{bus}
 }
 

--- a/mpu6050/mpu6050.go
+++ b/mpu6050/mpu6050.go
@@ -15,11 +15,11 @@ type Device struct {
 	bus machine.I2C
 }
 
-// NewI2C creates a new MPU6050 connection. The I2C bus must already be
+// New creates a new MPU6050 connection. The I2C bus must already be
 // configured.
 //
 // This function only creates the Device object, it does not touch the device.
-func NewI2C(bus machine.I2C) Device {
+func New(bus machine.I2C) Device {
 	return Device{bus}
 }
 


### PR DESCRIPTION
Use New() constructor function for devices for simplicity sake. Resolves https://github.com/aykevl/tinygo-drivers/issues/1