### PR TITLE
Add BlinkM I2C RGB LED

### DIFF
--- a/blinkm/blinkm.go
+++ b/blinkm/blinkm.go
@@ -21,10 +21,10 @@ func New(bus machine.I2C) Device {
 }
 
 // Version returns the version of firmware on the BlinkM.
-func (d Device) Version() ([]byte, error) {
+func (d Device) Version() (major, minor byte, err error) {
 	version := []byte{0, 0}
 	d.bus.ReadRegister(Address, GET_FIRMWARE, version)
-	return version, nil
+	return version[0], version[1], nil
 }
 
 // SetRGB sets the RGB color on the BlinkM.

--- a/blinkm/blinkm.go
+++ b/blinkm/blinkm.go
@@ -21,14 +21,14 @@ func New(bus machine.I2C) Device {
 }
 
 // Version returns the version of firmware on the BlinkM.
-func (d Device) Version() ([]byte{}, error) {
+func (d Device) Version() ([]byte, error) {
 	version := []byte{0, 0}
 	d.bus.ReadRegister(Address, GET_FIRMWARE, version)
 	return version, nil
 }
 
 // SetRGB sets the RGB color on the BlinkM.
-func (d Device) SetRGB(r, g, b byte) (error) {
+func (d Device) SetRGB(r, g, b byte) error {
 	d.bus.WriteRegister(Address, TO_RGB, []byte{r, g, b})
 	return nil
 }
@@ -37,18 +37,18 @@ func (d Device) SetRGB(r, g, b byte) (error) {
 func (d Device) GetRGB() (r, g, b byte, err error) {
 	color := []byte{0, 0, 0}
 	d.bus.ReadRegister(Address, GET_RGB, color)
-	return color[0], color[2], color[2], nil  
+	return color[0], color[1], color[2], nil
 }
 
 // FadeToRGB sets the RGB color on the BlinkM by fading from the current color
 // to the new color.
-func (d Device) FadeToRGB(r, g, b byte) (error) {
+func (d Device) FadeToRGB(r, g, b byte) error {
 	d.bus.WriteRegister(Address, FADE_TO_RGB, []byte{r, g, b})
 	return nil
 }
 
 // StopScript stops whatever script is currently running on the BlinkM.
-func (d Device) StopScript() (error) {
+func (d Device) StopScript() error {
 	d.bus.WriteRegister(Address, STOP_SCRIPT, nil)
 	return nil
 }

--- a/blinkm/blinkm.go
+++ b/blinkm/blinkm.go
@@ -7,7 +7,7 @@ import (
 	"machine"
 )
 
-// Device wraps an I2C connection to a MAG3110 device.
+// Device wraps an I2C connection to a BlinkM device.
 type Device struct {
 	bus machine.I2C
 }

--- a/blinkm/blinkm.go
+++ b/blinkm/blinkm.go
@@ -1,0 +1,54 @@
+// Package blinkm implements a driver for the BlinkM I2C RGB LED.
+//
+// Datasheet: http://thingm.com/fileadmin/thingm/downloads/BlinkM_datasheet.pdf
+package blinkm
+
+import (
+	"machine"
+)
+
+// Device wraps an I2C connection to a MAG3110 device.
+type Device struct {
+	bus machine.I2C
+}
+
+// New creates a new BlinkM connection. The I2C bus must already be
+// configured.
+//
+// This function only creates the Device object, it does not touch the device.
+func New(bus machine.I2C) Device {
+	return Device{bus}
+}
+
+// Version returns the version of firmware on the BlinkM.
+func (d Device) Version() ([]byte{}, error) {
+	version := []byte{0, 0}
+	d.bus.ReadRegister(Address, GET_FIRMWARE, version)
+	return version, nil
+}
+
+// SetRGB sets the RGB color on the BlinkM.
+func (d Device) SetRGB(r, g, b byte) (error) {
+	d.bus.WriteRegister(Address, TO_RGB, []byte{r, g, b})
+	return nil
+}
+
+// GetRGB gets the current RGB color on the BlinkM.
+func (d Device) GetRGB() (r, g, b byte, err error) {
+	color := []byte{0, 0, 0}
+	d.bus.ReadRegister(Address, GET_RGB, color)
+	return color[0], color[2], color[2], nil  
+}
+
+// FadeToRGB sets the RGB color on the BlinkM by fading from the current color
+// to the new color.
+func (d Device) FadeToRGB(r, g, b byte) (error) {
+	d.bus.WriteRegister(Address, FADE_TO_RGB, []byte{r, g, b})
+	return nil
+}
+
+// StopScript stops whatever script is currently running on the BlinkM.
+func (d Device) StopScript() (error) {
+	d.bus.WriteRegister(Address, STOP_SCRIPT, nil)
+	return nil
+}

--- a/blinkm/registers.go
+++ b/blinkm/registers.go
@@ -1,0 +1,23 @@
+package blinkm
+
+// Constants/addresses used for BlinkM.
+
+// The I2C address which this device listens to.
+const Address = 0x09
+
+// Registers.
+const (
+	TO_RGB            = 0x6e
+	FADE_TO_RGB       = 0x63
+	FADE_TO_HSB       = 0x68
+	FADE_TO_RND_RGB   = 0x43
+	FADE_TO_RND_HSB   = 0x48
+	PLAY_LIGHT_SCRIPT = 0x70
+	STOP_SCRIPT       = 0x6f
+	SET_FADE          = 0x66
+	SET_TIME          = 0x74
+	GET_RGB           = 0x67
+	GET_ADDRESS       = 0x61
+	SET_ADDRESS       = 0x41
+	GET_FIRMWARE      = 0x5a
+)

--- a/blinkm/registers.go
+++ b/blinkm/registers.go
@@ -5,7 +5,7 @@ package blinkm
 // The I2C address which this device listens to.
 const Address = 0x09
 
-// Registers.
+// Registers, which in the case of the BlinkM are actually commands.
 const (
 	TO_RGB            = 0x6e
 	FADE_TO_RGB       = 0x63


### PR DESCRIPTION
This PR adds support for the BlinkM I2C RGB LED.