### PR TITLE
WS2812 interface changes

### DIFF
--- a/ws2812/ws2812.go
+++ b/ws2812/ws2812.go
@@ -2,6 +2,7 @@
 package ws2812
 
 import (
+	"image/color"
 	"machine"
 )
 
@@ -25,12 +26,12 @@ func (d Device) Write(buf []byte) (n int, err error) {
 }
 
 // Write the given color slice out using the WS2812 protocol.
-// Colors are specified in RGB format, and are send out in the common GRB
-// format.
-func (d Device) WriteColors(buf []uint32) {
+// Colors are sent out in the usual GRB format.
+func (d Device) WriteColors(buf []color.RGBA) error {
 	for _, color := range buf {
-		d.WriteByte(byte(color >> 8))  // green
-		d.WriteByte(byte(color >> 16)) // red
-		d.WriteByte(byte(color >> 0))  // blue
+		d.WriteByte(color.G) // green
+		d.WriteByte(color.R) // red
+		d.WriteByte(color.B) // blue
 	}
+	return nil
 }

--- a/ws2812/ws2812.go
+++ b/ws2812/ws2812.go
@@ -17,10 +17,11 @@ func New(pin machine.GPIO) Device {
 }
 
 // Write the raw bitstring out using the WS2812 protocol.
-func (d Device) Write(buf []byte) {
+func (d Device) Write(buf []byte) (n int, err error) {
 	for _, c := range buf {
 		d.WriteByte(c)
 	}
+	return len(buf), nil
 }
 
 // Write the given color slice out using the WS2812 protocol.

--- a/ws2812/ws2812_avr_16m.go
+++ b/ws2812/ws2812_avr_16m.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Send a single byte using the WS2812 protocol.
-func (d Device) WriteByte(c byte) {
+func (d Device) WriteByte(c byte) error {
 	// For the AVR at 16MHz
 	portSet, maskSet := d.Pin.PortMaskSet()
 	portClear, maskClear := d.Pin.PortMaskClear()
@@ -38,4 +38,5 @@ func (d Device) WriteByte(c byte) {
 		"maskClear": maskClear,
 		"portClear": portClear,
 	})
+	return nil
 }

--- a/ws2812/ws2812_m0_16m.go
+++ b/ws2812/ws2812_m0_16m.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Send a single byte using the WS2812 protocol.
-func (d Device) WriteByte(c byte) {
+func (d Device) WriteByte(c byte) error {
 	// For the Cortex-M0 at 16MHz
 	portSet, maskSet := d.Pin.PortMaskSet()
 	portClear, maskClear := d.Pin.PortMaskClear()
@@ -40,4 +40,5 @@ func (d Device) WriteByte(c byte) {
 		"maskClear": maskClear,
 		"portClear": portClear,
 	})
+	return nil
 }


### PR DESCRIPTION
A few changes to make WS2812 compatible with APA102 (see #7).
@deadprogram what do you think of this interface?
In my code, code size is slightly increased. I'm not entirely sure why, but I think it's because some extra bit shifts and masks are necessary to insert values into and extract values from `image/color.RGBA`. I still think the change is worth it, though, for an easier-to-read interface.